### PR TITLE
Fix Instant-Shell Blocking on Dynamic Slug Routes

### DIFF
--- a/app/(cv)/cv/project/[slug]/page.tsx
+++ b/app/(cv)/cv/project/[slug]/page.tsx
@@ -1,3 +1,5 @@
+import { Suspense } from "react";
+
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 
@@ -6,12 +8,12 @@ import { ProjectExperience } from "@/components/project-experience";
 import { projectExperienceData } from "@/data/project-experience-data";
 import { metadataWithCustomOgImage } from "@/utils/metadata-utils";
 
-interface ProjectExperienceProps {
+type ProjectExperienceProps = {
   params: Promise<{
     slug: string;
   }>;
   searchParams?: Promise<{ [key: string]: string | string[] | undefined }>;
-}
+};
 
 export async function generateStaticParams() {
   return projectExperienceData.map(projectExperienceItem => ({
@@ -39,7 +41,11 @@ export async function generateMetadata({ params }: ProjectExperienceProps): Prom
   );
 }
 
-export default async function ProjectExperiencePage({ params }: ProjectExperienceProps) {
+async function ProjectExperienceContent({
+  params
+}: {
+  params: ProjectExperienceProps["params"];
+}) {
   const { slug } = await params;
   const projectExperience = projectExperienceData.find(
     projectExperienceItem => projectExperienceItem.slug === slug
@@ -50,4 +56,12 @@ export default async function ProjectExperiencePage({ params }: ProjectExperienc
   }
 
   return <ProjectExperience projectExperience={projectExperience} />;
+}
+
+export default function ProjectExperiencePage({ params }: ProjectExperienceProps) {
+  return (
+    <Suspense fallback={null}>
+      <ProjectExperienceContent params={params} />
+    </Suspense>
+  );
 }

--- a/app/(cv)/cv/project/[slug]/page.tsx
+++ b/app/(cv)/cv/project/[slug]/page.tsx
@@ -5,14 +5,13 @@ import { notFound } from "next/navigation";
 
 import { ProjectExperience } from "@/components/project-experience";
 
-import { projectExperienceData } from "@/data/project-experience-data";
+import { getProjectExperience, projectExperienceData } from "@/data/project-experience-data";
 import { metadataWithCustomOgImage } from "@/utils/metadata-utils";
 
 type ProjectExperienceProps = {
   params: Promise<{
     slug: string;
   }>;
-  searchParams?: Promise<{ [key: string]: string | string[] | undefined }>;
 };
 
 export async function generateStaticParams() {
@@ -23,9 +22,7 @@ export async function generateStaticParams() {
 
 export async function generateMetadata({ params }: ProjectExperienceProps): Promise<Metadata> {
   const { slug } = await params;
-  const projectExperience = projectExperienceData.find(
-    projectExperienceItem => projectExperienceItem.slug === slug
-  );
+  const projectExperience = getProjectExperience(slug);
 
   if (!projectExperience) {
     return {};
@@ -41,15 +38,9 @@ export async function generateMetadata({ params }: ProjectExperienceProps): Prom
   );
 }
 
-async function ProjectExperienceContent({
-  params
-}: {
-  params: ProjectExperienceProps["params"];
-}) {
+async function ProjectExperienceContent({ params }: Pick<ProjectExperienceProps, "params">) {
   const { slug } = await params;
-  const projectExperience = projectExperienceData.find(
-    projectExperienceItem => projectExperienceItem.slug === slug
-  );
+  const projectExperience = getProjectExperience(slug);
 
   if (!projectExperience) {
     return notFound();
@@ -60,7 +51,7 @@ async function ProjectExperienceContent({
 
 export default function ProjectExperiencePage({ params }: ProjectExperienceProps) {
   return (
-    <Suspense fallback={null}>
+    <Suspense>
       <ProjectExperienceContent params={params} />
     </Suspense>
   );

--- a/app/(main)/post/[slug]/page.tsx
+++ b/app/(main)/post/[slug]/page.tsx
@@ -1,3 +1,5 @@
+import { Suspense } from "react";
+
 import type { Metadata } from "next";
 import Image from "next/image";
 import Link from "next/link";
@@ -12,9 +14,9 @@ import { HistoryBackLink } from "@/components/history-back-link";
 import { getHumanizedDateFromNow } from "@/utils/date-utils";
 import { metadataWithCustomOgImage } from "@/utils/metadata-utils";
 
-interface PostPageProps {
+type PostPageProps = {
   params: Promise<{ slug: string }>;
-}
+};
 
 export async function generateStaticParams() {
   const slugs = await getPostSlugs();
@@ -39,7 +41,7 @@ export async function generateMetadata({ params }: PostPageProps): Promise<Metad
   return metadataWithCustomOgImage(title, description, "post");
 }
 
-export default async function PostPage({ params }: PostPageProps) {
+async function PostContent({ params }: { params: PostPageProps["params"] }) {
   const { slug } = await params;
 
   let Post: (props: Record<string, never>) => React.ReactNode;
@@ -58,8 +60,7 @@ export default async function PostPage({ params }: PostPageProps) {
   const title = typeof metadata.title === "string" ? metadata.title : slug;
 
   return (
-    <article className="relative container prose max-w-3xl prose-zinc dark:prose-invert">
-      <HistoryBackLink href="/post">See all posts</HistoryBackLink>
+    <>
       <div>
         <Heading variant="h1" className="mb-8 text-2xl font-semibold">
           {title}
@@ -99,6 +100,17 @@ export default async function PostPage({ params }: PostPageProps) {
         </div>
       </div>
       <Post />
+    </>
+  );
+}
+
+export default function PostPage({ params }: PostPageProps) {
+  return (
+    <article className="relative container prose max-w-3xl prose-zinc dark:prose-invert">
+      <HistoryBackLink href="/post">See all posts</HistoryBackLink>
+      <Suspense fallback={null}>
+        <PostContent params={params} />
+      </Suspense>
     </article>
   );
 }

--- a/app/(main)/post/[slug]/page.tsx
+++ b/app/(main)/post/[slug]/page.tsx
@@ -5,7 +5,7 @@ import Image from "next/image";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 
-import { getPostSlugs } from "@/lib/posts";
+import { getPost, getPostSlugs } from "@/lib/posts";
 import { formatDate } from "@/lib/utils";
 
 import { Heading } from "@/components/heading";
@@ -26,38 +26,27 @@ export async function generateStaticParams() {
 
 export async function generateMetadata({ params }: PostPageProps): Promise<Metadata> {
   const { slug } = await params;
+  const post = await getPost(slug);
 
-  let post: { metadata: Metadata };
-  try {
-    post = await import(`../_posts/${slug}.mdx`);
-  } catch {
+  if (!post) {
     return {};
   }
 
-  const metadata = post.metadata ?? {};
-  const title = typeof metadata.title === "string" ? metadata.title : slug;
-  const description = metadata.description ?? undefined;
+  const description =
+    typeof post.metadata.description === "string" ? post.metadata.description : undefined;
 
-  return metadataWithCustomOgImage(title, description, "post");
+  return metadataWithCustomOgImage(post.title, description, "post");
 }
 
-async function PostContent({ params }: { params: PostPageProps["params"] }) {
+async function PostContent({ params }: Pick<PostPageProps, "params">) {
   const { slug } = await params;
+  const post = await getPost(slug);
 
-  let Post: (props: Record<string, never>) => React.ReactNode;
-  let meta: { date?: string; shortDescription?: string; authors?: string[] };
-  let metadata: Metadata;
-
-  try {
-    const mod = await import(`../_posts/${slug}.mdx`);
-    Post = mod.default;
-    meta = mod.meta ?? {};
-    metadata = mod.metadata ?? {};
-  } catch {
+  if (!post) {
     notFound();
   }
 
-  const title = typeof metadata.title === "string" ? metadata.title : slug;
+  const { Content, meta, title } = post;
 
   return (
     <>
@@ -99,7 +88,7 @@ async function PostContent({ params }: { params: PostPageProps["params"] }) {
           ) : null}
         </div>
       </div>
-      <Post />
+      <Content />
     </>
   );
 }
@@ -108,7 +97,7 @@ export default function PostPage({ params }: PostPageProps) {
   return (
     <article className="relative container prose max-w-3xl prose-zinc dark:prose-invert">
       <HistoryBackLink href="/post">See all posts</HistoryBackLink>
-      <Suspense fallback={null}>
+      <Suspense>
         <PostContent params={params} />
       </Suspense>
     </article>

--- a/app/@modal/(.)cv/project/[slug]/page.tsx
+++ b/app/@modal/(.)cv/project/[slug]/page.tsx
@@ -4,14 +4,11 @@ import { notFound } from "next/navigation";
 
 import { ProjectExperience } from "@/components/project-experience";
 
-import { projectExperienceData } from "@/data/project-experience-data";
+import { getProjectExperience } from "@/data/project-experience-data";
 
 async function InterceptedProjectExperience({ params }: { params: Promise<{ slug: string }> }) {
   const { slug } = await params;
-
-  const projectExperience = projectExperienceData.find(
-    projectExperienceItem => projectExperienceItem.slug === slug
-  );
+  const projectExperience = getProjectExperience(slug);
 
   if (!projectExperience) {
     return notFound();
@@ -22,7 +19,7 @@ async function InterceptedProjectExperience({ params }: { params: Promise<{ slug
 
 export default function ProjectExperiencePage({ params }: { params: Promise<{ slug: string }> }) {
   return (
-    <Suspense fallback={null}>
+    <Suspense>
       <InterceptedProjectExperience params={params} />
     </Suspense>
   );

--- a/data/project-experience-data.ts
+++ b/data/project-experience-data.ts
@@ -424,6 +424,10 @@ const projectExperienceData: ProjectExperienceItem[] = [
   }
 ];
 
+export function getProjectExperience(slug: string): ProjectExperienceItem | null {
+  return projectExperienceData.find(item => item.slug === slug) ?? null;
+}
+
 export { projectExperienceData };
 
 export type { ProjectExperienceItem };

--- a/lib/posts.ts
+++ b/lib/posts.ts
@@ -1,4 +1,4 @@
-import type { ReactNode } from "react";
+import { cache, type ReactNode } from "react";
 
 import type { Metadata } from "next";
 import { cacheLife } from "next/cache";
@@ -28,13 +28,10 @@ export type PostModule = {
   title: string;
 };
 
-// Build-time local MDX import: mdxRs resolves this at compile time (not uncached
-// runtime IO). Path is relative to lib/posts.ts. cacheLife("max") because the
-// value only changes on a new build.
-export async function getPost(slug: string): Promise<PostModule | null> {
-  "use cache";
-  cacheLife("max");
-
+// Do not use "use cache" here: that boundary requires serializable return values,
+// and Content is a function (MDX component). React.cache only dedupes per request.
+// Path is relative to lib/posts.ts; mdxRs resolves the import at compile time.
+export const getPost = cache(async (slug: string): Promise<PostModule | null> => {
   try {
     const mod = await import(`../app/(main)/post/_posts/${slug}.mdx`);
 
@@ -47,7 +44,7 @@ export async function getPost(slug: string): Promise<PostModule | null> {
   } catch {
     return null;
   }
-}
+});
 
 export async function getPostSlugs(): Promise<string[]> {
   "use cache";

--- a/lib/posts.ts
+++ b/lib/posts.ts
@@ -1,3 +1,6 @@
+import type { ReactNode } from "react";
+
+import type { Metadata } from "next";
 import { cacheLife } from "next/cache";
 
 import { promises as fs } from "fs";
@@ -12,9 +15,40 @@ export type PostListItem = {
   shortDescription?: string;
 };
 
-// The post set is fixed per deployment — cache the filesystem read + local .mdx imports so
-// Cache Components treats them as prerendered data, not uncached runtime IO. cacheLife("max")
-// because the value only changes on a new build.
+export type PostMeta = {
+  date?: string;
+  shortDescription?: string;
+  authors?: string[];
+};
+
+export type PostModule = {
+  Content: () => ReactNode;
+  metadata: Metadata;
+  meta: PostMeta;
+  title: string;
+};
+
+// Build-time local MDX import: mdxRs resolves this at compile time (not uncached
+// runtime IO). Path is relative to lib/posts.ts. cacheLife("max") because the
+// value only changes on a new build.
+export async function getPost(slug: string): Promise<PostModule | null> {
+  "use cache";
+  cacheLife("max");
+
+  try {
+    const mod = await import(`../app/(main)/post/_posts/${slug}.mdx`);
+
+    return {
+      Content: mod.default,
+      metadata: mod.metadata ?? {},
+      meta: mod.meta ?? {},
+      title: typeof mod.metadata?.title === "string" ? mod.metadata.title : slug
+    };
+  } catch {
+    return null;
+  }
+}
+
 export async function getPostSlugs(): Promise<string[]> {
   "use cache";
   cacheLife("max");
@@ -32,14 +66,17 @@ export async function getPosts(): Promise<PostListItem[]> {
   const posts: PostListItem[] = [];
 
   for (const slug of slugs) {
-    // Build-time read of a LOCAL module: mdxRs resolves this at compile time
-    // (not uncached runtime IO). Path is relative to lib/posts.ts.
-    const mod = await import(`../app/(main)/post/_posts/${slug}.mdx`);
+    const post = await getPost(slug);
+
+    if (!post) {
+      continue;
+    }
+
     posts.push({
       slug,
-      title: typeof mod.metadata?.title === "string" ? mod.metadata.title : slug,
-      date: mod.meta?.date ?? "",
-      shortDescription: mod.meta?.shortDescription ?? mod.metadata?.description ?? undefined
+      title: post.title,
+      date: post.meta.date ?? "",
+      shortDescription: post.meta.shortDescription ?? post.metadata.description ?? undefined
     });
   }
 


### PR DESCRIPTION
## Fix Instant-Shell Blocking on Dynamic Slug Routes

- Wrap `await params` in Suspense on `/post/[slug]` and `/cv/project/[slug]` so cacheComponents instant-shell validation no longer blocks navigation
- Add cached `getPost` and `getProjectExperience` helpers so Suspense-wrapped routes and metadata share one slug-lookup path
- Reuse `getPost` in the post list loader and drop the unused `searchParams` type on the project page
